### PR TITLE
Allow passing argument string to rubocop when starting it from the task

### DIFF
--- a/lib/inquisition/version.rb
+++ b/lib/inquisition/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Inquisition
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/lib/tasks/inquisition.rake
+++ b/lib/tasks/inquisition.rake
@@ -163,8 +163,8 @@ namespace :inquisition do
   end
 
   desc 'Run Rubocop'
-  task :rubocop do
-    system 'bundle exec rubocop'
+  task :rubocop, :rubocop_arguments do |task, args|
+    system "bundle exec rubocop #{args.rubocop_arguments}"
   end
 
   desc 'Run Rails Best Practices'


### PR DESCRIPTION
Allow passing argument to rubocop, when it is run using `rails inquisition:rubocop`

Now we will finally be able to run it with autocorrect or in parallel:
`rails inquisition:rubocop[-a]` -- that's how we pass arguments