### PR TITLE
[bugfix] Rename module Errors to Error

### DIFF
--- a/exe/inquisition
+++ b/exe/inquisition
@@ -4,11 +4,11 @@ require 'inquisition'
 require 'inquisition/cli'
 
 CODE_INTERRUPT_EXCEPTIONS = [
-  Inquisition::Errors::BaseConfigAbsenseError,
-  Inquisition::Errors::NoConfigFileError,
-  Inquisition::Errors::InvalidRubyVersionError,
-  Inquisition::Errors::AdditionalSoftwareAbsenceError,
-  Inquisition::Errors::NoGemError
+  Inquisition::Error::BaseConfigAbsenseError,
+  Inquisition::Error::NoConfigFileError,
+  Inquisition::Error::InvalidRubyVersionError,
+  Inquisition::Error::AdditionalSoftwareAbsenceError,
+  Inquisition::Error::NoGemError
 ].freeze
 
 begin


### PR DESCRIPTION
### Description
Rename Inquisition::Errors to Inquisition::Error

### Before submitting the merge request make sure the following are checked

- [x] Followed the style guidelines of this project
- [x] Performed a self-review of own code
- [ ] Wrote the tests that prove that fix is effective/that feature works
