### PR TITLE
PEO-314 Provide an ability to configure gem

### DIFF
--- a/exe/inquisition
+++ b/exe/inquisition
@@ -4,11 +4,11 @@ require 'inquisition'
 require 'inquisition/cli'
 
 CODE_INTERRUPT_EXCEPTIONS = [
-  Inquisition::Errors::BaseConfigAbsenseError,
-  Inquisition::Errors::NoConfigFileError,
-  Inquisition::Errors::InvalidRubyVersionError,
-  Inquisition::Errors::AdditionalSoftwareAbsenceError,
-  Inquisition::Errors::NoGemError
+  Inquisition::Error::BaseConfigAbsenseError,
+  Inquisition::Error::NoConfigFileError,
+  Inquisition::Error::InvalidRubyVersionError,
+  Inquisition::Error::AdditionalSoftwareAbsenceError,
+  Inquisition::Error::NoGemError
 ].freeze
 
 begin

--- a/lib/inquisition/configuration.rb
+++ b/lib/inquisition/configuration.rb
@@ -1,0 +1,29 @@
+require 'singleton'
+
+module Inquisition
+  class Configuration
+    include Singleton
+
+    CONFIG_FILE_NAME = '.inquisition.yml'.freeze
+    ROOT_PATH = Dir.pwd
+    DEFAULT_HASH = { 'plugins' => [], 'verbose' => false }.freeze
+
+    def to_h
+      config_exist? ? data_config.to_h : DEFAULT_HASH
+    end
+
+    def verbose?
+      to_h['verbose']
+    end
+
+    private
+
+    def config_exist?
+      Dir.glob(File.join(ROOT_PATH, CONFIG_FILE_NAME)).any?
+    end
+
+    def data_config
+      YAML.load_file(File.join(ROOT_PATH, CONFIG_FILE_NAME))
+    end
+  end
+end

--- a/lib/inquisition/configure.rb
+++ b/lib/inquisition/configure.rb
@@ -13,7 +13,6 @@ module Inquisition
       def installers
         {
           Auditors::Backend::Installer => :backend,
-          Auditors::Frontend::Installer => :frontend,
           Auditors::Common::Installer => :common
         }
       end

--- a/lib/inquisition/runner.rb
+++ b/lib/inquisition/runner.rb
@@ -12,7 +12,6 @@ module Inquisition
     def runners
       {
         Auditors::Backend::Runner => :backend
-        # Auditors::Frontend::Runner => config_path(:frontend)
         # Auditors::Common::Runner => config_path(:common)
       }
     end

--- a/spec/inquisition/auditors/frontend/installer_spec.rb
+++ b/spec/inquisition/auditors/frontend/installer_spec.rb
@@ -1,6 +1,6 @@
-RSpec.describe Inquisition::Auditors::Frontend::Installer do
+RSpec.describe Inquisition::Auditors::Backend::Installer do
   describe '#call' do
-    subject { Inquisition::Auditors::Frontend::Configure.call }
+    subject { Inquisition::Auditors::Backend::Configure.call }
 
     xit 'run frontend configure' do
     end

--- a/spec/inquisition/configuration_spec.rb
+++ b/spec/inquisition/configuration_spec.rb
@@ -1,0 +1,44 @@
+require 'yaml'
+
+RSpec.describe Inquisition::Configuration, type: :unit do
+  let(:config_file) { Inquisition::Configuration::CONFIG_FILE_NAME }
+  let(:user_configure_file) { { 'plugins' => [], 'verbose' => true } }
+  let(:default_hash) { Inquisition::Configuration::DEFAULT_HASH }
+  subject { Inquisition::Configuration.instance }
+
+  describe '#to_h' do
+    context 'when config file exists' do
+      before do
+        File.open("./spec/fixtures/#{config_file}", 'w') { |f| f.write user_configure_file.to_yaml }
+      end
+
+      it 'file exist' do
+        allow(subject).to receive(:config_exist?).and_return(true)
+        allow(subject).to receive(:data_config).and_return(user_configure_file)
+        expect(subject.to_h).to eq(user_configure_file)
+      end
+
+      after { File.delete("./spec/fixtures/#{config_file}") }
+    end
+
+    context 'when config file not exists' do
+      it 'file not exist' do
+        expect(subject.to_h).to eq(default_hash)
+      end
+    end
+  end
+
+  describe '#verbose?' do
+    context 'check verbose true or false' do
+      it 'return false' do
+        allow(subject).to receive(:to_h).and_return(default_hash)
+        expect(subject.verbose?).to eq(false)
+      end
+
+      it 'return true' do
+        allow(subject).to receive(:to_h).and_return(user_configure_file)
+        expect(subject.verbose?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/inquisition/configure_spec.rb
+++ b/spec/inquisition/configure_spec.rb
@@ -16,14 +16,6 @@ RSpec.describe Inquisition::Configure, type: :unit do
         it_behaves_like 'call callable objects', Inquisition::Auditors::Backend::Installer => 'backend configure'
       end
 
-      context 'when frontend configurers are enabled' do
-        before do
-          allow(Inquisition::BaseConfig.instance).to receive(:auditor_enabled?).with(:frontend).and_return(true)
-        end
-
-        it_behaves_like 'call callable objects', Inquisition::Auditors::Frontend::Installer => 'frontend configure'
-      end
-
       context 'when common configurers are enabled' do
         before do
           allow(Inquisition::BaseConfig.instance).to receive(:auditor_enabled?).with(:common).and_return(true)


### PR DESCRIPTION
[PEO-314](https://garage.atlassian.net/browse/PEO-314)

### Description

Replace this text with a summary of the changes in your merge request
Need to create a class which will be responsible for gem configuration.
This object should able to do next:
read configuration provided by the user in the .inquisition.yml fileplugins:rubocop:enabled: true | falseWhen true -> disable rubocop lintWhen false -> enable rubocop lintreek:enabled: true | false

verbose: false | true
When true -> turn on logger to STDOUT
When false -> turn off logger
if file absent it returns a default value of the configurationplugins: []verbose: false
Configuration should respond on the next instance method
Configuration#.to_h return a hash of the configuration
Configuration should be as a singleton

- [x] Followed the style guidelines of this project
- [x] Performed a self-review of own code
- [x] Wrote the tests that prove that fix is effective/that feature works
